### PR TITLE
Add missing <pthread.h> include in inc/mtp.h header

### DIFF
--- a/inc/mtp.h
+++ b/inc/mtp.h
@@ -26,6 +26,8 @@
 #ifndef _INC_MTP_H_
 #define _INC_MTP_H_
 
+#include <pthread.h>
+
 #define MAX_STORAGE_NB 16
 #define MAX_CFG_STRING_SIZE 512
 


### PR DESCRIPTION
This fixes the build under GCC 8 with the musl C library.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>