### PR TITLE
mtp_operations: Add missing include

### DIFF
--- a/src/mtp_operations/mtp_op_sendobject.c
+++ b/src/mtp_operations/mtp_op_sendobject.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
 #include "logs_out.h"
 


### PR DESCRIPTION
Add missing <sys/stat.h> include, required to use S_IRUSR / S_IWUSR.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>