### PR TITLE
Add handling of "umask", changing the permissions of any uploaded file

### DIFF
--- a/conf/umtprd.conf
+++ b/conf/umtprd.conf
@@ -7,6 +7,7 @@
 # Set to 1 to don't shutdown uMTPrd when the link is disconnected.
 
 loop_on_disconnect 0
+umask 022
 
 #storage command : Create add a storage entry point. Up to 16 entry points supported
 #Syntax : storage "PATH" "NAME"

--- a/inc/mtp.h
+++ b/inc/mtp.h
@@ -69,6 +69,7 @@ typedef struct mtp_usb_cfg_
 	int loop_on_disconnect;
 
 	int show_hidden_files;
+	int val_umask;
 
 }mtp_usb_cfg;
 

--- a/inc/mtp_operations.h
+++ b/inc/mtp_operations.h
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_operations.h
  * @brief  MTP operations
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 uint32_t mtp_op_OpenSession(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hdr, int * size,uint32_t * ret_params, int * ret_params_size);

--- a/inc/mtp_ops_helpers.h
+++ b/inc/mtp_ops_helpers.h
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_ops_helpers.h
  * @brief  mtp operations helpers
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 mtp_size send_file_data( mtp_ctx * ctx, fs_entry * entry,mtp_offset offset, mtp_size maxsize );

--- a/src/mtp_cfg.c
+++ b/src/mtp_cfg.c
@@ -71,6 +71,7 @@ enum
 	LOOP_ON_DISCONNECT,
 
 	SHOW_HIDDEN_FILES,
+	UMASK,
 
 	NO_INOTIFY
 
@@ -409,7 +410,27 @@ static int get_str_param(mtp_ctx * context, char * line,int cmd)
 	return 0;
 }
 
-kw_list kwlist[] =
+static int get_oct_param(mtp_ctx * context, char * line,int cmd)
+{
+    int i;
+    char tmp_txt[MAX_CFG_STRING_SIZE];
+    unsigned long param_value;
+
+    i = get_param(line, 1, tmp_txt);
+
+    if (i >= 0) {
+        param_value = strtol(tmp_txt, 0, 8);
+        switch (cmd) {
+            case UMASK:
+                context->usb_cfg.val_umask = param_value;
+                break;
+
+        }
+    }
+    return 0;
+}
+
+                kw_list kwlist[] =
 {
 	{"storage",                get_storage_params, STORAGE_CMD},
 	{"usb_vendor_id",          get_hex_param,   USBVENDORID_CMD},
@@ -438,6 +459,7 @@ kw_list kwlist[] =
 	{"loop_on_disconnect",     get_hex_param,   LOOP_ON_DISCONNECT},
 
 	{"show_hidden_files",      get_hex_param,   SHOW_HIDDEN_FILES},
+	{"umask",                  get_oct_param,   UMASK},
 
 	{"no_inotify",             get_hex_param,   NO_INOTIFY},
 
@@ -516,6 +538,7 @@ int mtp_load_config_file(mtp_ctx * context, const char * conffile)
 	context->usb_cfg.loop_on_disconnect = 0;
 
 	context->usb_cfg.show_hidden_files = 1;
+	context->usb_cfg.val_umask = 0111;
 
 	context->no_inotify = 0;
 
@@ -573,6 +596,7 @@ int mtp_load_config_file(mtp_ctx * context, const char * conffile)
 	PRINT_MSG("Wait for connection : %i",context->usb_cfg.wait_connection);
 	PRINT_MSG("Loop on disconnect : %i",context->usb_cfg.loop_on_disconnect);
 	PRINT_MSG("Show hidden files : %i",context->usb_cfg.show_hidden_files);
+	PRINT_MSG("umask : %03o",context->usb_cfg.val_umask);
 	PRINT_MSG("inotify : %s",context->no_inotify?"no":"yes");
 
 	return err;

--- a/src/mtp_operations/mtp_op_begineditobject.c
+++ b/src/mtp_operations/mtp_op_begineditobject.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_begineditobject.c
  * @brief  begin edit object operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_closesession.c
+++ b/src/mtp_operations/mtp_op_closesession.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_closesession.c
  * @brief  Close session operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_deleteobject.c
+++ b/src/mtp_operations/mtp_op_deleteobject.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_deleteobject.c
  * @brief  Delete object operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_endeditobject.c
+++ b/src/mtp_operations/mtp_op_endeditobject.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_endeditobject.c
  * @brief  End edit object operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getdeviceinfos.c
+++ b/src/mtp_operations/mtp_op_getdeviceinfos.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getdeviceinfos.c
  * @brief  get device infos operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getdevicepropdesc.c
+++ b/src/mtp_operations/mtp_op_getdevicepropdesc.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getdevicepropdesc.c
  * @brief  get device prop desc operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getdevicepropvalue.c
+++ b/src/mtp_operations/mtp_op_getdevicepropvalue.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getdevicepropvalue.c
  * @brief  get device prop value operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getobject.c
+++ b/src/mtp_operations/mtp_op_getobject.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getobject.c
  * @brief  get object operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getobjecthandles.c
+++ b/src/mtp_operations/mtp_op_getobjecthandles.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getobjecthandles.c
  * @brief  get object handles operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getobjectinfo.c
+++ b/src/mtp_operations/mtp_op_getobjectinfo.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getobjectinfo.c
  * @brief  get object info operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getobjectpropdesc.c
+++ b/src/mtp_operations/mtp_op_getobjectpropdesc.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getobjectpropdesc.c
  * @brief  get object prop desc operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getobjectproplist.c
+++ b/src/mtp_operations/mtp_op_getobjectproplist.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getobjectproplist.c
  * @brief  get object prop list operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getobjectpropssupported.c
+++ b/src/mtp_operations/mtp_op_getobjectpropssupported.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getobjectpropssupported.c
  * @brief  get object props supported operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getobjectpropvalue.c
+++ b/src/mtp_operations/mtp_op_getobjectpropvalue.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getobjectpropvalue.c
  * @brief  get oject prop value operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getobjectreferences.c
+++ b/src/mtp_operations/mtp_op_getobjectreferences.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getobjectreferences.c
  * @brief  get object references operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getpartialobject.c
+++ b/src/mtp_operations/mtp_op_getpartialobject.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getpartialobject.c
  * @brief  get partial object operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getstorageids.c
+++ b/src/mtp_operations/mtp_op_getstorageids.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getstorageids.c
  * @brief  get storage ids operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_getstorageinfo.c
+++ b/src/mtp_operations/mtp_op_getstorageinfo.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_getstorageinfo.c
  * @brief  get storage info operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_opensession.c
+++ b/src/mtp_operations/mtp_op_opensession.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_opensession.c
  * @brief  open session operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_sendobject.c
+++ b/src/mtp_operations/mtp_op_sendobject.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_sendobject.c
  * @brief  send object operation.
- * @author Jean-Fran�ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_sendobject.c
+++ b/src/mtp_operations/mtp_op_sendobject.c
@@ -85,7 +85,7 @@ uint32_t mtp_op_SendObject(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hdr, int
 						if( mtp_packet_hdr->code == MTP_OPERATION_SEND_PARTIAL_OBJECT )
 							file = open(full_path,O_RDWR | O_LARGEFILE);
 						else
-							file = open(full_path,O_CREAT|O_WRONLY|O_TRUNC,S_IRUSR|S_IWUSR | O_LARGEFILE);
+							file = open(full_path,O_CREAT|O_WRONLY|O_TRUNC| O_LARGEFILE, S_IRUSR|S_IWUSR);
 
 						if( file != -1 )
 						{

--- a/src/mtp_operations/mtp_op_sendobject.c
+++ b/src/mtp_operations/mtp_op_sendobject.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_sendobject.c
  * @brief  send object operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-Franï¿½ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"
@@ -135,6 +135,7 @@ uint32_t mtp_op_SendObject(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hdr, int
 							ctx->transferring_file_data = 0;
 
 							close(file);
+							chmod(full_path, 0777 & (~ctx->usb_cfg.val_umask));
 
 							if(ctx->cancel_req)
 							{

--- a/src/mtp_operations/mtp_op_sendobjectinfo.c
+++ b/src/mtp_operations/mtp_op_sendobjectinfo.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_sendobjectinfo.c
  * @brief  send object info operation
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_setobjectpropvalue.c
+++ b/src/mtp_operations/mtp_op_setobjectpropvalue.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_setobjectpropvalue.c
  * @brief  set object prop value operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_op_truncateobject.c
+++ b/src/mtp_operations/mtp_op_truncateobject.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_op_truncateobject.c
  * @brief  truncate object operation.
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_operations/mtp_ops_helpers.c
+++ b/src/mtp_operations/mtp_ops_helpers.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_ops_helpers.c
  * @brief  mtp operations helpers
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"

--- a/src/mtp_properties.c
+++ b/src/mtp_properties.c
@@ -20,7 +20,7 @@
 /**
  * @file   mtp_properties.c
  * @brief  MTP properties datasets helpers
- * @author Jean-François DEL NERO <Jean-Francois.DELNERO@viveris.fr>
+ * @author Jean-FranÃ§ois DEL NERO <Jean-Francois.DELNERO@viveris.fr>
  */
 
 #include "buildconf.h"


### PR DESCRIPTION
"umask" entry was introduced in configuration file. the octal value will mask the permissions of any newly created files.
This allows, for example, to permit other programs to read the uploaded files (currently, files are created with 600 permissions, so only root can read the file).

This also fixes one wrong flag passed to open() during file creation. It seems mostly harmless, because in many platforms O_LARGEFILE == 0. But this may not be true in other platforms, altering the permissions of the newly created files.