### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+obj/
+umtprd


### PR DESCRIPTION
This PR adds a .gitignore file to ignore binary objects, because I want to be able to `git add .` my changes rather than having to add individual files.