### PR TITLE
Check that fs handles db is valid before using it to get entries

### DIFF
--- a/src/fs_handles_db.c
+++ b/src/fs_handles_db.c
@@ -643,7 +643,7 @@ void entry_close(int file)
 
 fs_entry * get_entry_by_wd( fs_handles_db * db, int watch_descriptor, fs_entry * entry_list )
 {
-	if(!entry_list)
+	if(!entry_list && db)
 		entry_list = db->entry_list;
 
 	while( entry_list )
@@ -661,7 +661,7 @@ fs_entry * get_entry_by_wd( fs_handles_db * db, int watch_descriptor, fs_entry *
 
 fs_entry * get_entry_by_storageid( fs_handles_db * db, uint32_t storage_id, fs_entry * entry_list )
 {
-	if(!entry_list)
+	if(!entry_list && db)
 		entry_list = db->entry_list;
 
 	while( entry_list )


### PR DESCRIPTION
This fixes a crash for me from issue #29 when ejecting the removable storage media while not attached to a host.