### PR TITLE
src/fs_handles_db.c: Fix segmentation fault

### DIFF
--- a/src/fs_handles_db.c
+++ b/src/fs_handles_db.c
@@ -174,7 +174,8 @@ DIR * fs_find_first_file(char *folder, filefoundinfo* fileinfo)
 
 		}
 
-		closedir(dir);
+		if (dir)
+			closedir(dir);
 		dir = NULL;
 	}
 	else


### PR DESCRIPTION
closedir(NULL) causes a segmentation fault within uClibc.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>