### PR TITLE
Add addstorage/rmstorage commands

### DIFF
--- a/inc/mtp.h
+++ b/inc/mtp.h
@@ -141,6 +141,7 @@ void mtp_set_usb_handle(mtp_ctx * ctx, void * handle, uint32_t max_packet_size);
 int mtp_load_config_file(mtp_ctx * context, const char * conffile);
 
 uint32_t mtp_add_storage(mtp_ctx * ctx, char * path, char * description, uint32_t flags);
+int mtp_remove_storage(mtp_ctx * ctx, char * name);
 int mtp_get_storage_index_by_name(mtp_ctx * ctx, char * name);
 uint32_t mtp_get_storage_id_by_name(mtp_ctx * ctx, char * name);
 char * mtp_get_storage_description(mtp_ctx * ctx, uint32_t storage_id);

--- a/inc/mtp_cfg.h
+++ b/inc/mtp_cfg.h
@@ -27,4 +27,6 @@
 #include "mtp.h"
 
 int mtp_create_storage(mtp_ctx * context);
+void mtp_add_storage_from_line(mtp_ctx *context, char *line, int idx);
+int mtp_remove_storage_from_line(mtp_ctx * context, char * name, int idx);
 #endif

--- a/src/msgqueue.c
+++ b/src/msgqueue.c
@@ -41,6 +41,7 @@
 #include <errno.h>
 
 #include "mtp.h"
+#include "mtp_cfg.h"
 #include "mtp_helpers.h"
 #include "mtp_constant.h"
 #include "mtp_datasets.h"
@@ -88,6 +89,14 @@ void* msgqueue_thread( void* arg )
 		if( msgrcv(ctx->msgqueue_id, &msg_buf, sizeof(msg_buf), 1, 0) > 0 )
 		{
 			PRINT_DEBUG("msgqueue_thread : New message received : %s",msg_buf.mesg_text);
+
+			if (!strncmp(msg_buf.mesg_text,"addstorage:", 11)) {
+				mtp_add_storage_from_line(ctx, &msg_buf.mesg_text[11], 0);
+			}
+
+			if (!strncmp(msg_buf.mesg_text,"rmstorage:", 10)) {
+				mtp_remove_storage_from_line(ctx, &msg_buf.mesg_text[10], 0);
+			}
 
 			if(!strncmp((char*)&msg_buf.mesg_text,"mount:",6))
 			{

--- a/src/mtp.c
+++ b/src/mtp.c
@@ -647,6 +647,9 @@ uint32_t mtp_add_storage(mtp_ctx * ctx, char * path, char * description, uint32_
 
 	PRINT_DEBUG("mtp_add_storage : %s", path );
 
+	if (mtp_get_storage_id_by_name(ctx, description) != 0xFFFFFFFF)
+		return 0x00000000;
+
 	i = 0;
 	while(i < MAX_STORAGE_NB)
 	{

--- a/src/mtp.c
+++ b/src/mtp.c
@@ -692,6 +692,24 @@ uint32_t mtp_add_storage(mtp_ctx * ctx, char * path, char * description, uint32_
 	return 0x00000000;
 }
 
+int mtp_remove_storage(mtp_ctx * ctx, char * name)
+{
+	int index = mtp_get_storage_index_by_name(ctx, name);
+
+	if (index < 0)
+		return index;
+
+	free(ctx->storages[index].root_path);
+	free(ctx->storages[index].description);
+
+	ctx->storages[index].root_path = NULL;
+	ctx->storages[index].description = NULL;
+	ctx->storages[index].flags = 0x00000000;
+	ctx->storages[index].storage_id = 0x00000000;
+
+	return 0;
+}
+
 uint32_t mtp_get_storage_id_by_name(mtp_ctx * ctx, char * name)
 {
 	int i;

--- a/src/mtp_cfg.c
+++ b/src/mtp_cfg.c
@@ -159,8 +159,7 @@ static int get_param_offset(char * line, int param)
 	offs = 0;
 	offs = get_next_word(line, offs);
 
-	param_cnt = 0;
-	do
+	for (param_cnt = 0; param_cnt < param; param_cnt++)
 	{
 		offs = copy_param(NULL, line, offs);
 
@@ -168,9 +167,7 @@ static int get_param_offset(char * line, int param)
 
 		if(line[offs] == 0 || line[offs] == '#')
 			return -1;
-
-		param_cnt++;
-	}while( param_cnt < param );
+	}
 
 	return offs;
 }

--- a/src/mtp_cfg.c
+++ b/src/mtp_cfg.c
@@ -241,7 +241,21 @@ int test_flag(char * str, char * flag)
 	return 0;
 }
 
-static int get_storage_params(mtp_ctx * context, char * line,int cmd)
+int mtp_remove_storage_from_line(mtp_ctx * context, char * name, int idx)
+{
+	char storagename[MAX_CFG_STRING_SIZE];
+	int i;
+
+	i = get_param(name, idx, storagename);
+	if (i < 0)
+		return i;
+
+	PRINT_MSG("Remove storage %s", storagename);
+
+	return mtp_remove_storage(context, storagename);
+}
+
+void mtp_add_storage_from_line(mtp_ctx * context, char * line, int idx)
 {
 	int i, j, k;
 	char storagename[MAX_CFG_STRING_SIZE];
@@ -249,13 +263,13 @@ static int get_storage_params(mtp_ctx * context, char * line,int cmd)
 	char options[MAX_CFG_STRING_SIZE];
 	uint32_t flags;
 
-	i = get_param(line, 2,storagename);
-	j = get_param(line, 1,storagepath);
+	i = get_param(line, idx + 1,storagename);
+	j = get_param(line, idx,storagepath);
 	flags = UMTP_STORAGE_READWRITE;
 
 	if( i >= 0 && j >= 0 )
 	{
-		k = get_param(line, 3,options);
+		k = get_param(line, idx + 2,options);
 		if( k >= 0 )
 		{
 			if(test_flag(options, "ro"))
@@ -278,6 +292,11 @@ static int get_storage_params(mtp_ctx * context, char * line,int cmd)
 
 		mtp_add_storage(context, storagepath, storagename, flags);
 	}
+}
+
+static int get_storage_params(mtp_ctx * context, char * line,int cmd)
+{
+	mtp_add_storage_from_line(context, line, 1);
 
 	return 0;
 }


### PR DESCRIPTION
These two commands allow to dynamically add and remove storages.

This is useful e.g. when the storage mountpoints and/or names are not known in advance.