### PR TITLE
Fix inotify for root folders when using multiple storages

### DIFF
--- a/src/mtp_operations/mtp_op_getobjecthandles.c
+++ b/src/mtp_operations/mtp_op_getobjecthandles.c
@@ -90,7 +90,7 @@ uint32_t mtp_op_GetObjectHandles(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hd
 		// root folder
 		parent_handle = 0x00000000;
 		full_path = mtp_get_storage_root(ctx,storageid);
-		entry = get_entry_by_handle(ctx->fs_db, parent_handle);
+		entry = get_entry_by_handle_and_storageid(ctx->fs_db, parent_handle, storageid);
 	}
 
 	nb_of_handles = 0;


### PR DESCRIPTION
When using multiple storages, changes in some of the root folders can't be seen at the initiator (observed with Windows 10 and Ubuntu 18.04). This seems to be caused by a wrong assignment of the inotify watch descriptor for the root directories.

In mtp_op_GetObjectHandles() the entry object was always retrieved by calling get_entry_by_handle() with the parent_handle == 0. Thus always the same entry was returned for all storages and the inotify watch descriptors for the root folders got assigned always to the same entry.
