### PR TITLE
Fix output_dir make dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,15 @@ objects := $(sources:src/%.c=obj/%.o)
 ops_sources := $(wildcard src/mtp_operations/*.c)
 ops_objects := $(ops_sources:src/mtp_operations/%.c=obj/%.o)
 
-all: output_dir umtprd
+all: umtprd
 
 umtprd: $(objects) $(ops_objects)
 	${CC} -o $@    $^ $(LDFLAGS) -lpthread
 
-$(objects): obj/%.o: src/%.c
+$(objects): obj/%.o: src/%.c | output_dir
 	${CC} -o $@ $^ -c $(CPPFLAGS) $(CFLAGS)
 
-$(ops_objects): obj/%.o: src/mtp_operations/%.c
+$(ops_objects): obj/%.o: src/mtp_operations/%.c | output_dir
 	${CC} -o $@ $^ -c $(CPPFLAGS) $(CFLAGS)
 
 output_dir:


### PR DESCRIPTION
Object file targets need to depend on the output_dir target.

Fixes:
```
make --shuffle=reverse -j1
cc -o obj/mtp_op_truncateobject.o src/mtp_operations/mtp_op_truncateobject.c -c  -I./inc -lpthread -Wall -O3 Assembler messages:
Fatal error: can't create obj/mtp_op_truncateobject.o: No such file or directory
make: *** [Makefile:19: obj/mtp_op_truncateobject.o] Error 1 shuffle=reverse
```