### PR TITLE
fix default permissions and umask handling

### DIFF
--- a/src/mtp.c
+++ b/src/mtp.c
@@ -269,7 +269,7 @@ int parse_incomming_dataset(mtp_ctx * ctx,void * datain,int size,uint32_t * newh
 
 							if(!set_storage_giduid(ctx, entry->storage_id))
 							{
-								ret = mkdir(tmp_path, 0700);
+								ret = mkdir(tmp_path, 0777);
 							}
 
 							restore_giduid(ctx);
@@ -287,9 +287,6 @@ int parse_incomming_dataset(mtp_ctx * ctx,void * datain,int size,uint32_t * newh
 
 								return ret_code;
 							}
-
-							if(ctx->usb_cfg.val_umask >= 0)
-								chmod(tmp_path, 0777 & (~ctx->usb_cfg.val_umask));
 
 							tmp_file_entry.isdirectory = 1;
 							strcpy(tmp_file_entry.filename,tmp_str);
@@ -362,7 +359,9 @@ int parse_incomming_dataset(mtp_ctx * ctx,void * datain,int size,uint32_t * newh
 
 							if(!set_storage_giduid(ctx, storage_id))
 							{
-								file = open(tmp_path,O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE, S_IRUSR|S_IWUSR);
+								file = open(tmp_path,
+										O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE,
+										S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 							}
 
 							restore_giduid(ctx);

--- a/src/mtp_cfg.c
+++ b/src/mtp_cfg.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "mtp.h"
@@ -760,6 +761,7 @@ int mtp_load_config_file(mtp_ctx * context, const char * conffile)
 	PRINT_MSG("Show hidden files : %i",context->usb_cfg.show_hidden_files);
 	if(context->usb_cfg.val_umask >= 0)
 	{
+		umask(context->usb_cfg.val_umask);
 		PRINT_MSG("File creation umask : %03o",context->usb_cfg.val_umask);
 	}
 	else

--- a/src/mtp_operations/mtp_op_sendobject.c
+++ b/src/mtp_operations/mtp_op_sendobject.c
@@ -93,7 +93,9 @@ uint32_t mtp_op_SendObject(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hdr, int
 							if( mtp_packet_hdr->code == MTP_OPERATION_SEND_PARTIAL_OBJECT )
 								file = open(full_path,O_RDWR | O_LARGEFILE);
 							else
-								file = open(full_path,O_CREAT|O_WRONLY|O_TRUNC| O_LARGEFILE, S_IRUSR|S_IWUSR);
+								file = open(full_path,
+										O_CREAT | O_WRONLY | O_TRUNC | O_LARGEFILE,
+										S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 						}
 
 						restore_giduid(ctx);
@@ -149,9 +151,6 @@ uint32_t mtp_op_SendObject(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hdr, int
 							ctx->transferring_file_data = 0;
 
 							close(file);
-
-							if(ctx->usb_cfg.val_umask >= 0)
-								chmod(full_path, 0777 & (~ctx->usb_cfg.val_umask));
 
 							if(ctx->cancel_req)
 							{


### PR DESCRIPTION
On linux files are usually created with permissions set to 666+umask, and folders with 777+umask.

The codebase used to create files with 600 and folders with 700 *unless* a umask override was set in the configuration, then both files and folders would end up with 777+umask.

This patch addresses this by setting the umask override on process level; Creating files with permissions set to 666 and folders set to 777 - with either the overridden or the system default umask applied.