### PR TITLE
Fix dangling symlinks handling

### DIFF
--- a/src/fs_handles_db.c
+++ b/src/fs_handles_db.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <errno.h>
 
 #include "mtp.h"
 #include "mtp_helpers.h"
@@ -139,6 +140,10 @@ int fs_entry_stat(char *path, filefoundinfo* fileinfo)
 		return 1;
 	}
 
+	PRINT_WARN("stat64(%s) error: %s",path, strerror(errno));
+	fileinfo->size = 0;
+	fileinfo->filename[0] = '\0';
+
 	return 0;
 }
 
@@ -151,8 +156,7 @@ DIR * fs_find_first_file(char *folder, filefoundinfo* fileinfo)
 	dir = opendir (folder);
 	if( dir )
 	{
-		d = readdir (dir);
-		if( d )
+		while ((d = readdir (dir)) != NULL)
 		{
 			tmpstr = malloc (strlen(folder) + strlen(d->d_name) + 4 );
 			if( tmpstr )


### PR DESCRIPTION
When umtp encounters a directory with a dangling symlink, it would wrongly presume an access issue, log and error:
MTP_OPERATION_GET_OBJECT_HANDLES : FOLDER ACCESS ERROR ! 
and the host/client would throw an "Input/output error" at the user.

The fix is rather straight-forward: have the "fs_find_first_file" actually iterate over the entries returned by "readdir", and not just stop at the (possibly broken) first.

Also log the error as PRINT_WARNING in the daemon's log output, so that a user can diagnose&fix the issue.

----
```
# to reproduce/test:
mkdir -p /mnt/data/mtp-storage/symlink
echo aaa >  /mnt/data/mtp-storage/symlink/AAA
ln -s /tmp/bbb  /mnt/data/mtp-storage/symlink/BBB
echo ccc >  /mnt/data/mtp-storage/symlink/CCC

# which would (now) list on the host:
$host> ls mtp-mountpoint/symlink/
AAA 
CCC
```