### PR TITLE
Add option to call fsync() before close() during mtp_op_SendObject()

### DIFF
--- a/conf/umtprd.conf
+++ b/conf/umtprd.conf
@@ -81,6 +81,14 @@ usb_dev_version 0x3008
 
 # no_inotify 0x1
 
+# Sync when close
+# Set this option to 0x1 to request all file data to be flushed from the RAM buffer to the
+# internal storage after transfer is completed, this prevents data loss in the case where
+# user un-plugged a non-battery-powered device too soon when there are still buffered data
+# stayed in the RAM
+
+# sync_when_close 0x0 
+
 #
 # Internal buffers size
 #

--- a/inc/mtp.h
+++ b/inc/mtp.h
@@ -135,6 +135,8 @@ typedef struct mtp_ctx_
 
 	int no_inotify;
 
+	int sync_when_close;
+
 	int uid,euid;
 	int gid,egid;
 

--- a/src/mtp_cfg.c
+++ b/src/mtp_cfg.c
@@ -78,7 +78,9 @@ enum
 	DEFAULT_UID_CMD,
 	DEFAULT_GID_CMD,
 
-	NO_INOTIFY
+	NO_INOTIFY,
+
+	SYNC_WHEN_CLOSE
 
 };
 
@@ -478,6 +480,9 @@ static int get_hex_param(mtp_ctx * context, char * line,int cmd)
 				context->no_inotify = param_value;
 			break;
 
+			case SYNC_WHEN_CLOSE:
+				context->sync_when_close = param_value;
+
 		}
 	}
 
@@ -617,6 +622,8 @@ kw_list kwlist[] =
 
 	{"no_inotify",             get_hex_param,   NO_INOTIFY},
 
+	{"sync_when_close",        get_hex_param,   SYNC_WHEN_CLOSE},
+
 	{ 0, 0, 0 }
 };
 
@@ -702,6 +709,7 @@ int mtp_load_config_file(mtp_ctx * context, const char * conffile)
 	context->default_uid = -1;
 
 	context->no_inotify = 0;
+	context->sync_when_close = 0;
 
 	f = fopen(conffile, "r");
 	if(f)
@@ -786,6 +794,8 @@ int mtp_load_config_file(mtp_ctx * context, const char * conffile)
 	}
 
 	PRINT_MSG("inotify : %s",context->no_inotify?"no":"yes");
+
+	PRINT_MSG("Sync when close : %s",context->sync_when_close?"yes":"no");
 
 	return err;
 }

--- a/src/mtp_operations/mtp_op_sendobject.c
+++ b/src/mtp_operations/mtp_op_sendobject.c
@@ -148,6 +148,7 @@ uint32_t mtp_op_SendObject(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hdr, int
 
 							ctx->transferring_file_data = 0;
 
+							if (ctx->sync_when_close) fsync(file);
 							close(file);
 
 							if(ctx->usb_cfg.val_umask >= 0)


### PR DESCRIPTION
On a non-battery-powered device (or a device that can be powered off by, say, a hardware power cut-off switch), data loss could occur because file buffer in RAM cannot be fully written to the internal storage before kernel-not-expected power off.

Without this patch, such device can only set their storage into sync mode to ensure all data are written to storage without caching, and that greatly reduce the write performance.

This PR includes:
1. add fsync() before close() call in mtp_op_SendObject(), to ensure all bytes received are written to the storage before the file is closed.
2. a variable "sync_when_close" in the ctx, and an option in the config to enable/disable this option. (Default is disabled to retain current behavior)