### PR TITLE
Update USB device paths in built-in config

### DIFF
--- a/inc/default_cfg.h
+++ b/inc/default_cfg.h
@@ -43,11 +43,11 @@
 
 #define USB_FFS_MODE 1
 
-#define USB_DEV     "/dev/ffs-umtp/ep0"
+#define USB_DEV     "/dev/ffs-mtp/ep0"
 
-#define USB_EPIN    "/dev/ffs-umtp/ep1"
-#define USB_EPOUT   "/dev/ffs-umtp/ep2"
-#define USB_EPINTIN "/dev/ffs-umtp/ep3"
+#define USB_EPIN    "/dev/ffs-mtp/ep1"
+#define USB_EPOUT   "/dev/ffs-mtp/ep2"
+#define USB_EPINTIN "/dev/ffs-mtp/ep3"
 
 #define MANUFACTURER "Viveris Technologies"
 #define PRODUCT      "The Viveris Product !"


### PR DESCRIPTION
The built-in default config used /dev/ffs-umtp/ as the path to the endpoints, whereas both the sample umtprd.conf file and the umtprd-ffs.sh file used /dev/ffs-mtp/.
Change the built-in default config to also use /dev/ffs-mtp, so that the startup script can be used out of the box without having to put the config file in /etc.