### PR TITLE
Rework command line argument handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CFLAGS += -I./inc -lpthread -Wall
+CFLAGS += -I./inc -Wall
+LDFLAGS += -lpthread
 
 sources := $(wildcard src/*.c)
 objects := $(sources:src/%.c=obj/%.o)
@@ -29,7 +30,7 @@ endif
 all: umtprd
 
 umtprd: $(objects) $(ops_objects)
-	${CC} -o $@    $^ $(LDFLAGS) -lpthread
+	${CC} -o $@    $^ $(LDFLAGS)
 
 $(objects): obj/%.o: src/%.c | output_dir
 	${CC} -o $@ $^ -c $(CPPFLAGS) $(CFLAGS)

--- a/src/inotify.c
+++ b/src/inotify.c
@@ -30,6 +30,7 @@
 #include <pthread.h>
 #include <string.h>
 #include <sys/inotify.h>
+#include <sys/prctl.h>
 #include <unistd.h>
 #include <signal.h>
 
@@ -108,6 +109,8 @@ static void* inotify_thread(void* arg)
 	char inotify_buffer[INOTIFY_RD_BUF_SIZE] __attribute__ ((aligned(__alignof__(struct inotify_event))));
 	const struct inotify_event *event;
 	struct sigaction sa;
+
+	prctl(PR_SET_NAME, (unsigned long) __func__);
 
 	ctx = (mtp_ctx *)arg;
 

--- a/src/inotify.c
+++ b/src/inotify.c
@@ -88,12 +88,12 @@ static int get_file_info(mtp_ctx * ctx, const struct inotify_event *event, fs_en
 	return 0;
 }
 
-void *inotify_gotsig(int sig, siginfo_t *info, void *ucontext)
+static void *inotify_gotsig(int sig, siginfo_t *info, void *ucontext)
 {
 	return NULL;
 }
 
-void* inotify_thread(void* arg)
+static void* inotify_thread(void* arg)
 {
 	mtp_ctx * ctx;
 	int i, length;

--- a/src/msgqueue.c
+++ b/src/msgqueue.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <signal.h>
 
+#include <sys/prctl.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -71,6 +72,8 @@ static void* msgqueue_thread( void* arg )
 	uint32_t handle[3];
 	int store_index;
 	struct sigaction sa;
+
+	prctl(PR_SET_NAME, (unsigned long) __func__);
 
 	ctx = (mtp_ctx *)arg;
 

--- a/src/msgqueue.c
+++ b/src/msgqueue.c
@@ -59,12 +59,12 @@ typedef struct mesg_buffer_ {
 	char mesg_text[MAX_MSG_SIZE];
 } queue_msg_buf;
 
-void *msgqueue_gotsig(int sig, siginfo_t *info, void *ucontext)
+static void *msgqueue_gotsig(int sig, siginfo_t *info, void *ucontext)
 {
 	return NULL;
 }
 
-void* msgqueue_thread( void* arg )
+static void* msgqueue_thread( void* arg )
 {
 	mtp_ctx * ctx;
 	queue_msg_buf msg_buf;
@@ -234,7 +234,7 @@ error:
 	return NULL;
 }
 
-int get_current_exec_path( char * exec_path, int maxsize )
+static int get_current_exec_path( char * exec_path, int maxsize )
 {
 	pid_t pid;
 	char path[PATH_MAX];

--- a/src/mtp.c
+++ b/src/mtp.c
@@ -422,7 +422,7 @@ int check_and_send_USB_ZLP(mtp_ctx * ctx , int size)
 	// USB ZLP needed ?
 	if( (size >= ctx->max_packet_size) && !(size % ctx->max_packet_size) )
 	{
-		PRINT_DEBUG("%d bytes transfert ended - ZLP packet needed", size);
+		PRINT_DEBUG("%d bytes transfer ended - ZLP packet needed", size);
 
 		// Yes - Send zero lenght packet.
 		write_usb(ctx->usb_ctx,EP_DESCRIPTOR_IN,ctx->wrbuffer,0);

--- a/src/mtp.c
+++ b/src/mtp.c
@@ -777,8 +777,6 @@ uint32_t mtp_get_storage_id_by_name(mtp_ctx * ctx, char * name)
 {
 	int i;
 
-	PRINT_DEBUG("mtp_get_storage_id_by_name : %s", name );
-
 	i = 0;
 	while(i < MAX_STORAGE_NB)
 	{
@@ -786,7 +784,8 @@ uint32_t mtp_get_storage_id_by_name(mtp_ctx * ctx, char * name)
 		{
 			if( !strcmp(ctx->storages[i].description, name ) )
 			{
-				PRINT_DEBUG("mtp_get_storage_id_by_name : %s -> %.8X",
+				PRINT_DEBUG("%s : %s -> %.8X",
+					    __func__,
 					    ctx->storages[i].root_path,
 						ctx->storages[i].storage_id);
 
@@ -796,14 +795,14 @@ uint32_t mtp_get_storage_id_by_name(mtp_ctx * ctx, char * name)
 		i++;
 	}
 
+	PRINT_DEBUG("%s : '%s' not found", __func__, name );
+
 	return 0xFFFFFFFF;
 }
 
 int mtp_get_storage_index_by_name(mtp_ctx * ctx, char * name)
 {
 	int i;
-
-	PRINT_DEBUG("mtp_get_storage_index_by_name : %s", name );
 
 	i = 0;
 	while(i < MAX_STORAGE_NB)
@@ -812,7 +811,8 @@ int mtp_get_storage_index_by_name(mtp_ctx * ctx, char * name)
 		{
 			if( !strcmp(ctx->storages[i].description, name ) )
 			{
-				PRINT_DEBUG("mtp_get_storage_index_by_name : %s -> %.8X",
+				PRINT_DEBUG("%s : %s -> %.8X",
+					    __func__,
 					    ctx->storages[i].root_path,
 						i);
 
@@ -822,14 +822,14 @@ int mtp_get_storage_index_by_name(mtp_ctx * ctx, char * name)
 		i++;
 	}
 
+	PRINT_DEBUG("%s : '%s' not found", __func__, name );
+
 	return -1;
 }
 
 int mtp_get_storage_index_by_id(mtp_ctx * ctx, uint32_t storage_id)
 {
 	int i;
-
-	PRINT_DEBUG("mtp_get_storage_index_by_id : 0x%X", storage_id );
 
 	i = 0;
 	while(i < MAX_STORAGE_NB)
@@ -838,7 +838,8 @@ int mtp_get_storage_index_by_id(mtp_ctx * ctx, uint32_t storage_id)
 		{
 			if( ctx->storages[i].storage_id == storage_id )
 			{
-				PRINT_DEBUG("mtp_get_storage_index_by_id : %.8X -> %d",
+				PRINT_DEBUG("%s : %.8X -> %d",
+					    __func__,
 					    storage_id,
 					    i );
 				return i;
@@ -847,14 +848,14 @@ int mtp_get_storage_index_by_id(mtp_ctx * ctx, uint32_t storage_id)
 		i++;
 	}
 
+	PRINT_DEBUG("%s : 0x%X not found", __func__, storage_id );
+
 	return -1;
 }
 
 char * mtp_get_storage_root(mtp_ctx * ctx, uint32_t storage_id)
 {
 	int i;
-
-	PRINT_DEBUG("mtp_get_storage_root : %.8X", storage_id );
 
 	i = 0;
 	while(i < MAX_STORAGE_NB)
@@ -863,7 +864,8 @@ char * mtp_get_storage_root(mtp_ctx * ctx, uint32_t storage_id)
 		{
 			if( ctx->storages[i].storage_id == storage_id )
 			{
-				PRINT_DEBUG("mtp_get_storage_root : %.8X -> %s",
+				PRINT_DEBUG("%s : %.8X -> %s",
+					    __func__,
 					    storage_id,
 					    ctx->storages[i].root_path );
 				return ctx->storages[i].root_path;
@@ -872,14 +874,13 @@ char * mtp_get_storage_root(mtp_ctx * ctx, uint32_t storage_id)
 		i++;
 	}
 
+	PRINT_DEBUG("%s : %.8X not found", __func__, storage_id );
 	return NULL;
 }
 
 char * mtp_get_storage_description(mtp_ctx * ctx, uint32_t storage_id)
 {
 	int i;
-
-	PRINT_DEBUG("mtp_get_storage_description : %.8X", storage_id );
 
 	i = 0;
 	while(i < MAX_STORAGE_NB)
@@ -888,7 +889,8 @@ char * mtp_get_storage_description(mtp_ctx * ctx, uint32_t storage_id)
 		{
 			if( ctx->storages[i].storage_id == storage_id )
 			{
-				PRINT_DEBUG("mtp_get_storage_description : %.8X -> %s",
+				PRINT_DEBUG("%s : %.8X -> %s",
+					    __func__,
 					    storage_id,
 					    ctx->storages[i].description );
 				return ctx->storages[i].description;
@@ -897,14 +899,14 @@ char * mtp_get_storage_description(mtp_ctx * ctx, uint32_t storage_id)
 		i++;
 	}
 
+	PRINT_DEBUG("%s : %.8X not found", __func__, storage_id );
+
 	return NULL;
 }
 
 uint32_t mtp_get_storage_flags(mtp_ctx * ctx, uint32_t storage_id)
 {
 	int i;
-
-	PRINT_DEBUG("mtp_get_storage_flags : %.8X", storage_id );
 
 	i = 0;
 	while(i < MAX_STORAGE_NB)
@@ -913,7 +915,8 @@ uint32_t mtp_get_storage_flags(mtp_ctx * ctx, uint32_t storage_id)
 		{
 			if( ctx->storages[i].storage_id == storage_id )
 			{
-				PRINT_DEBUG("mtp_get_storage_flags : %.8X -> 0x%.8X",
+				PRINT_DEBUG("%s : %.8X -> 0x%.8X",
+					    __func__,
 					    storage_id,
 					    ctx->storages[i].flags );
 				return ctx->storages[i].flags;
@@ -921,6 +924,8 @@ uint32_t mtp_get_storage_flags(mtp_ctx * ctx, uint32_t storage_id)
 		}
 		i++;
 	}
+
+	PRINT_DEBUG("%s : %.8X not found", __func__, storage_id );
 
 	return 0xFFFFFFFF;
 }

--- a/src/mtp_operations/mtp_ops_helpers.c
+++ b/src/mtp_operations/mtp_ops_helpers.c
@@ -164,7 +164,7 @@ mtp_size send_file_data( mtp_ctx * ctx, fs_entry * entry,mtp_offset offset, mtp_
 
 		if( ctx->cancel_req )
 		{
-			PRINT_DEBUG("send_file_data : Cancelled ! Aborded...");
+			PRINT_DEBUG("send_file_data : Cancelled ! Aborted...");
 
 			// Force a ZLP
 			check_and_send_USB_ZLP(ctx , ctx->max_packet_size );
@@ -174,7 +174,7 @@ mtp_size send_file_data( mtp_ctx * ctx, fs_entry * entry,mtp_offset offset, mtp_
 		}
 		else
 		{
-			PRINT_DEBUG("send_file_data : Full transfert done !");
+			PRINT_DEBUG("send_file_data : Full transfer done !");
 
 			check_and_send_USB_ZLP(ctx , sizeof(MTP_PACKET_HEADER) + actualsize );
 		}

--- a/src/umtprd.c
+++ b/src/umtprd.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <string.h>
+#include <sys/prctl.h>
 
 #ifdef SYSTEMD_NOTIFY
 #include <systemd/sd-login.h>
@@ -53,6 +54,8 @@ void* io_thread(void* arg)
 {
 	usb_gadget * ctx;
 	int ret;
+
+	prctl(PR_SET_NAME, (unsigned long) __func__);
 
 	ctx = (usb_gadget *)arg;
 

--- a/src/usb_gadget.c
+++ b/src/usb_gadget.c
@@ -521,7 +521,7 @@ static void handle_setup_request(usb_gadget * ctx, struct usb_ctrlrequest* setup
 			while( mtp_context->cancel_req )
 			{
 				// Still Waiting the end of the current transfer...
-				if( cnt > 500 )
+				if( cnt > 2500 ) // wait 2.5s max for cancel_req from the io_thread
 				{
 					// Still blocked... Killing the link
 					PRINT_DEBUG("MTP_REQ_CANCEL : Stalled ... Killing the link...");

--- a/src/usb_gadget.c
+++ b/src/usb_gadget.c
@@ -498,8 +498,6 @@ static void handle_setup_request(usb_gadget * ctx, struct usb_ctrlrequest* setup
 		case MTP_REQ_CANCEL:
 			PRINT_DEBUG("MTP_REQ_CANCEL !");
 
-			status = read (ctx->usb_device, &status, 0);
-
 			mtp_context->cancel_req = 1;
 
 			cnt = 0;

--- a/src/usb_gadget.c
+++ b/src/usb_gadget.c
@@ -223,7 +223,7 @@ void fill_ep_descriptor(mtp_ctx * ctx, usb_gadget * usbctx,struct usb_endpoint_d
 	if(flags & EP_BULK_MODE)
 	{
 		desc->bmAttributes = USB_ENDPOINT_XFER_BULK;
-		desc->wMaxPacketSize = ctx->usb_cfg.usb_max_packet_size;
+		desc->wMaxPacketSize = flags & EP_SS_MODE ? 1024 : 512;
 	}
 	else
 	{

--- a/src/usb_gadget.c
+++ b/src/usb_gadget.c
@@ -113,7 +113,7 @@ int write_usb(usb_gadget * ctx, int channel, unsigned char * buffer, int size)
 				{
 					ret = write (ctx->ep_handles[channel], buffer, size);
 				}
-			}while( ret < 0 && ( (errno == EAGAIN) || (errno == EAGAIN) ) && !mtp_context->cancel_req );
+			}while( ret < 0 && ( (errno == EAGAIN) || (errno == EWOULDBLOCK) ) && !mtp_context->cancel_req );
 			fcntl(ctx->ep_handles[channel], F_SETFL, fcntl(ctx->ep_handles[channel], F_GETFL) & ~O_NONBLOCK);
 #else
 

--- a/src/usb_gadget.c
+++ b/src/usb_gadget.c
@@ -238,10 +238,10 @@ void fill_ep_descriptor(mtp_ctx * ctx, usb_gadget * usbctx,struct usb_endpoint_d
 		ep_cfg_descriptor * ss_descriptor;
 
 		ss_descriptor = (ep_cfg_descriptor *)desc;
+		memset(&ss_descriptor->ep_desc_comp,0,sizeof(struct usb_ss_ep_comp_descriptor));
 
 		ss_descriptor->ep_desc_comp.bLength = sizeof(struct usb_ss_ep_comp_descriptor);
 		ss_descriptor->ep_desc_comp.bDescriptorType = USB_DT_SS_ENDPOINT_COMP;
-		ss_descriptor->ep_desc_comp.bMaxBurst = 15;
 	}
 #endif
 


### PR DESCRIPTION
Make it possible to specify multiple -cmd: parameters at once, and to specify them when starting umtprd, e.g. instead of doing

  umtrpd &
  umtprd '-cmd:addstorage:/home Home rw'
  umtprd '-cmd:addstorage:/data Data ro'

you can now do:

  umtprd '-cmd:addstorage:/home Home rw' '-cmd:addstorage:/data Data ro'

Also make it so the order of parameters doesn't matter, i.e. specifying "-conf" before "-cmd:" will work as one might expect.