### PR TITLE
Set names for threads

### DIFF
--- a/src/inotify.c
+++ b/src/inotify.c
@@ -30,6 +30,7 @@
 #include <pthread.h>
 #include <string.h>
 #include <sys/inotify.h>
+#include <sys/prctl.h>
 #include <unistd.h>
 #include <signal.h>
 
@@ -108,6 +109,8 @@ static void* inotify_thread(void* arg)
 	char inotify_buffer[INOTIFY_RD_BUF_SIZE] __attribute__ ((aligned(__alignof__(struct inotify_event))));
 	const struct inotify_event *event;
 	struct sigaction sa;
+
+	prctl(PR_SET_NAME, (unsigned long) __func__);
 
 	ctx = (mtp_ctx *)arg;
 

--- a/src/msgqueue.c
+++ b/src/msgqueue.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <signal.h>
 
+#include <sys/prctl.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -71,6 +72,8 @@ static void* msgqueue_thread( void* arg )
 	uint32_t handle[3];
 	int store_index;
 	struct sigaction sa;
+
+	prctl(PR_SET_NAME, (unsigned long) __func__);
 
 	ctx = (mtp_ctx *)arg;
 

--- a/src/umtprd.c
+++ b/src/umtprd.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <string.h>
+#include <sys/prctl.h>
 
 #ifdef SYSTEMD_NOTIFY
 #include <systemd/sd-login.h>
@@ -53,6 +54,8 @@ void* io_thread(void* arg)
 {
 	usb_gadget * ctx;
 	int ret;
+
+	prctl(PR_SET_NAME, (unsigned long) __func__);
 
 	ctx = (usb_gadget *)arg;
 


### PR DESCRIPTION
Have each of the worker threads set their name so they can be more easily identified with tools like "ps" or "pstree".