### PR TITLE
Make PRINT_* macros behave consistently

### DIFF
--- a/inc/logs_out.h
+++ b/inc/logs_out.h
@@ -63,42 +63,42 @@ void timestamp(char * timestr, int maxsize);
 
 #else // Stdout usage
 
-#define PRINT_MSG(fmt, args...)   {                                 \
+#define PRINT_MSG(fmt, args...)   do {                              \
                                     char timestr[32];               \
                                     timestamp((char*)&timestr, sizeof(timestr)); \
                                     fprintf(stdout,                 \
                                             "[uMTPrd - %s - Info] " fmt "\n",(char*)&timestr, \
                                             ## args);               \
                                     fflush(stdout);                 \
-                                  }
+                                  } while (0)
 
-#define PRINT_ERROR(fmt, args...) {                                 \
+#define PRINT_ERROR(fmt, args...) do {                              \
                                     char timestr[32];               \
                                     timestamp((char*)&timestr, sizeof(timestr)); \
                                     fprintf(stderr,                 \
                                             "[uMTPrd - %s - Error] " fmt "\n",(char*)&timestr, \
                                             ## args);               \
                                     fflush(stderr);                 \
-                                  }
+                                  } while (0)
 
-#define PRINT_WARN(fmt, args...)  {                                 \
+#define PRINT_WARN(fmt, args...)  do {                              \
                                     char timestr[32];               \
                                     timestamp((char*)&timestr, sizeof(timestr)); \
                                     fprintf(stdout,                 \
                                             "[uMTPrd - %s - Warning] " fmt "\n",(char*)&timestr, \
                                             ## args);               \
                                     fflush(stdout);                 \
-                                  }
+                                  } while (0)
 
 #ifdef DEBUG
-#define PRINT_DEBUG(fmt, args...) {                                 \
+#define PRINT_DEBUG(fmt, args...) do {                              \
                                     char timestr[32];               \
                                     timestamp((char*)&timestr, sizeof(timestr)); \
                                     fprintf(stdout,                 \
                                             "[uMTPrd - %s - Debug] " fmt "\n",(char*)&timestr, \
                                             ## args);               \
                                     fflush(stdout);                 \
-                                  }
+                                  } while (0)
 #else
 
 #define PRINT_DEBUG(fmt, args...)


### PR DESCRIPTION
The function-like PRINT_* macros would build differently for different build options, such that something like:

  if (condition)
    PRINT_MSG("yes")
  else
    PRINT_MSG("no")

(note the missing semicolons)
would build successfully with no additional build flags or with DEBUG=1, but would fail to compile with USE_SYSLOG=1.

This change makes it so that all build options cause the above to fail, same as if it had been a regular function call.