### PR TITLE
fix open-write-close chatter during SendObject 

### DIFF
--- a/inc/fs_handles_db.h
+++ b/inc/fs_handles_db.h
@@ -26,6 +26,8 @@
 #ifndef _INC_FS_HANDLES_DB_H_
 #define _INC_FS_HANDLES_DB_H_
 
+#include <sys/types.h>
+
 typedef struct fs_entry fs_entry;
 
 typedef int64_t mtp_size;
@@ -43,6 +45,7 @@ struct fs_entry
 	mtp_size size;
 	uint32_t date;
 
+	int file_descriptor;
 	int watch_descriptor;
 
 	fs_entry * next;
@@ -87,9 +90,9 @@ fs_entry * add_entry(fs_handles_db * db, filefoundinfo *fileinfo, uint32_t paren
 fs_entry * search_entry(fs_handles_db * db, filefoundinfo *fileinfo, uint32_t parent, uint32_t storage_id);
 fs_entry * alloc_root_entry(fs_handles_db * db, uint32_t storage_id);
 
-int entry_open(fs_handles_db * db, fs_entry * entry);
-int entry_read(fs_handles_db * db, int file, unsigned char * buffer_out, mtp_offset offset, mtp_size size);
-void entry_close(int file);
+int entry_open(fs_handles_db * db, fs_entry * entry, int flags, mode_t mode);
+int entry_read(fs_handles_db * db, fs_entry * entry, unsigned char * buffer_out, mtp_offset offset, mtp_size size);
+void entry_close(fs_handles_db * db, fs_entry * entry);
 
 char * build_full_path(fs_handles_db * db,char * root_path,fs_entry * entry);
 

--- a/src/fs_handles_db.c
+++ b/src/fs_handles_db.c
@@ -261,6 +261,8 @@ void deinit_fs_db(fs_handles_db * fsh)
 				fsh->entry_list->watch_descriptor = -1;
 			}
 
+			entry_close(fsh, fsh->entry_list);
+
 			if( fsh->entry_list->name )
 				free( fsh->entry_list->name );
 

--- a/src/fs_handles_db.c
+++ b/src/fs_handles_db.c
@@ -624,6 +624,9 @@ int entry_open(fs_handles_db * db, fs_entry * entry, int flags, mode_t mode)
 {
 	char * full_path;
 
+	if (entry->file_descriptor > 0)
+		return entry->file_descriptor;
+
 	full_path = build_full_path(db,mtp_get_storage_root(db->mtp_ctx, entry->storage_id), entry);
 	if( full_path )
 	{

--- a/src/fs_handles_db.c
+++ b/src/fs_handles_db.c
@@ -322,6 +322,7 @@ fs_entry * alloc_entry(fs_handles_db * db, filefoundinfo *fileinfo, uint32_t par
 
 		entry->size = fileinfo->size;
 
+		entry->file_descriptor = -1;
 		entry->watch_descriptor = -1;
 
 		if( fileinfo->isdirectory )
@@ -619,43 +620,38 @@ char * build_full_path(fs_handles_db * db,char * root_path,fs_entry * entry)
 	return full_path;
 }
 
-int entry_open(fs_handles_db * db, fs_entry * entry)
+int entry_open(fs_handles_db * db, fs_entry * entry, int flags, mode_t mode)
 {
-	int file;
 	char * full_path;
-
-	file = -1;
 
 	full_path = build_full_path(db,mtp_get_storage_root(db->mtp_ctx, entry->storage_id), entry);
 	if( full_path )
 	{
-		file = -1;
-
 		if(!set_storage_giduid(db->mtp_ctx, entry->storage_id))
 		{
-			file = open(full_path,O_RDONLY | O_LARGEFILE);
+			entry->file_descriptor = open(full_path, flags, mode);
 		}
 
 		restore_giduid(db->mtp_ctx);
 
-		if( file == -1 )
+		if( entry->file_descriptor == -1 )
 			PRINT_DEBUG("entry_open : Can't open %s !",full_path);
 
 		free(full_path);
 	}
 
-	return file;
+	return entry->file_descriptor;
 }
 
-int entry_read(fs_handles_db * db, int file, unsigned char * buffer_out, mtp_offset offset, mtp_size size)
+int entry_read(fs_handles_db * db, fs_entry * entry, unsigned char * buffer_out, mtp_offset offset, mtp_size size)
 {
 	int totalread;
 
-	if( file != -1 )
+	if( entry->file_descriptor != -1 )
 	{
-		lseek64(file, offset, SEEK_SET);
+		lseek64(entry->file_descriptor, offset, SEEK_SET);
 
-		totalread = read( file, buffer_out, size );
+		totalread = read( entry->file_descriptor, buffer_out, size );
 
 		return totalread;
 	}
@@ -663,10 +659,16 @@ int entry_read(fs_handles_db * db, int file, unsigned char * buffer_out, mtp_off
 	return 0;
 }
 
-void entry_close(int file)
+void entry_close(fs_handles_db * db, fs_entry * entry)
 {
-	if( file != -1 )
-		close(file);
+	if( entry->file_descriptor != -1 )
+	{
+		if (((mtp_ctx *)db->mtp_ctx)->sync_when_close)
+			fsync(entry->file_descriptor);
+
+		close(entry->file_descriptor);
+	}
+	entry->file_descriptor = -1;
 }
 
 fs_entry * get_entry_by_wd( fs_handles_db * db, int watch_descriptor, fs_entry * entry_list )

--- a/src/mtp_operations/mtp_op_endeditobject.c
+++ b/src/mtp_operations/mtp_op_endeditobject.c
@@ -52,6 +52,8 @@ uint32_t mtp_op_EndEditObject(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hdr, 
 
 	check_handle_access( ctx, NULL, handle, 1, &response_code);
 
+	entry_close(ctx->fs_db, get_entry_by_handle(ctx->fs_db, handle));
+
 	pthread_mutex_unlock( &ctx->inotify_mutex );
 
 	return response_code;

--- a/src/mtp_operations/mtp_op_sendobject.c
+++ b/src/mtp_operations/mtp_op_sendobject.c
@@ -147,7 +147,8 @@ uint32_t mtp_op_SendObject(mtp_ctx * ctx,MTP_PACKET_HEADER * mtp_packet_hdr, int
 
 						ctx->transferring_file_data = 0;
 
-						entry_close(ctx->fs_db, entry);
+						if( mtp_packet_hdr->code != MTP_OPERATION_SEND_PARTIAL_OBJECT )
+							entry_close(ctx->fs_db, entry);
 
 						if(ctx->cancel_req)
 						{


### PR DESCRIPTION
The current implementation that handles `MTP_OPERATION_SEND_PARTIAL_OBJECT` would repeatedly `open;write;close` during a transfer of a large file.
Which is undesirable when other processes in the system want to register with inotify to watch create/modify/close on a folder/file where access is provided over mtp.

The solution implemented here is to simply keep the file-descriptors around and open over the stream of `SendPartialObject` chunks.

The order of [MTP operations](https://en.wikipedia.org/wiki/Media_Transfer_Protocol#Android_extensions) is (or seems to be, always?):
`BeginEditObject`, `SendPartialObject` x chunk-size, `EndEditObject`.
Now the first SendPartial would open() the file, and the trailing EndEdit would then close() it. 


```
# Before:
$> inotifywatch /mnt/data/mtp-storage/
total  modify  close_write  open  filename
33368  29652   1858         1858  /mnt/data/mtp-storage/


# After (uploading a new file):
$> inotifywatch /mnt/data/mtp-storage/
total  access  modify  close_write  close_nowrite  open  create  filename
29696  10      29669   3            5              8     1       /mnt/data/mtp-storage/

# After (overwriting the same file):
$> inotifywatch /mnt/data/mtp-storage/
total  modify  close_write  open  filename
29692  29690   1            1     /mnt/data/mtp-storage/
```

----
The first couple of commits only refactor/deduplicate/move code around - and are (intentionally) split into small parts for ease of review ;-)
The last commit is the change this PR is actually interested in.

**CC** @bith3ad @gujie-leica