### PR TITLE
datasets: deviceinfo: clear MTP extension string to avoid libmtp quirks and USB resets

### DIFF
--- a/conf/umtprd.conf
+++ b/conf/umtprd.conf
@@ -60,6 +60,13 @@ serial "01234567"
 
 firmware_version "Rev A"
 
+# Set the mtp extensions to advertise
+# this string is inherited from the tizen source base, and can be set to the
+# empty string to avoid triggering a host sides libmtp's vendor-specific quirk
+# handling.
+
+mtp_extensions "microsoft.com: 1.0; android.com: 1.0;"
+
 # Set the USB interface string. Should be always "MTP"
 
 interface "MTP"

--- a/inc/mtp.h
+++ b/inc/mtp.h
@@ -63,6 +63,7 @@ typedef struct mtp_usb_cfg_
 	char usb_string_product[MAX_CFG_STRING_SIZE + 1];
 	char usb_string_serial[MAX_CFG_STRING_SIZE + 1];
 	char usb_string_version[MAX_CFG_STRING_SIZE + 1];
+	char usb_string_mtp_extensions[MAX_CFG_STRING_SIZE + 1];
 
 	char usb_string_interface[MAX_CFG_STRING_SIZE + 1];
 

--- a/inc/mtp_constant_strings.h
+++ b/inc/mtp_constant_strings.h
@@ -24,8 +24,6 @@
  */
 
 #ifndef _INC_MTP_CONSTANT_STRINGS_H_
-extern const char DevInfos_MTP_Extensions[];
-
 const char * mtp_get_operation_string(uint16_t operation);
 const char * mtp_get_property_string(uint16_t property);
 const char * mtp_get_format_string(uint16_t format);

--- a/src/mtp_cfg.c
+++ b/src/mtp_cfg.c
@@ -68,6 +68,7 @@ enum
 	PRODUCT_STRING_CMD,
 	SERIAL_STRING_CMD,
 	VERSION_STRING_CMD,
+	MTP_EXTENSIONS_STRING_CMD,
 	INTERFACE_STRING_CMD,
 
 	WAIT_CONNECTION,
@@ -527,6 +528,10 @@ static int get_str_param(mtp_ctx * context, char * line,int cmd)
 				strncpy(context->usb_cfg.usb_string_version,tmp_txt,MAX_CFG_STRING_SIZE);
 			break;
 
+			case MTP_EXTENSIONS_STRING_CMD:
+				strncpy(context->usb_cfg.usb_string_mtp_extensions,tmp_txt,MAX_CFG_STRING_SIZE);
+			break;
+
 			case INTERFACE_STRING_CMD:
 				strncpy(context->usb_cfg.usb_string_interface,tmp_txt,MAX_CFG_STRING_SIZE);
 			break;
@@ -680,6 +685,7 @@ int mtp_load_config_file(mtp_ctx * context, const char * conffile)
 	strncpy(context->usb_cfg.usb_string_product,      PRODUCT,                MAX_CFG_STRING_SIZE);
 	strncpy(context->usb_cfg.usb_string_serial,       SERIALNUMBER,           MAX_CFG_STRING_SIZE);
 	strncpy(context->usb_cfg.usb_string_version,      "Rev A",                MAX_CFG_STRING_SIZE);
+	strncpy(context->usb_cfg.usb_string_mtp_extensions, "",                   MAX_CFG_STRING_SIZE);
 	strncpy(context->usb_cfg.usb_string_interface,    "MTP",                  MAX_CFG_STRING_SIZE);
 
 	context->usb_cfg.usb_vendor_id       = USB_DEV_VENDOR_ID;
@@ -737,6 +743,7 @@ int mtp_load_config_file(mtp_ctx * context, const char * conffile)
 	PRINT_MSG("Product string : %s",context->usb_cfg.usb_string_product);
 	PRINT_MSG("Serial string : %s",context->usb_cfg.usb_string_serial);
 	PRINT_MSG("Firmware Version string : %s", context->usb_cfg.usb_string_version);
+	PRINT_MSG("MTP Exstensions string : %s", context->usb_cfg.usb_string_mtp_extensions);
 	PRINT_MSG("Interface string : %s",context->usb_cfg.usb_string_interface);
 
 	PRINT_MSG("USB Vendor ID : 0x%.4X",context->usb_cfg.usb_vendor_id);

--- a/src/mtp_constant_strings.c
+++ b/src/mtp_constant_strings.c
@@ -31,8 +31,6 @@
 #include "mtp.h"
 #include "mtp_constant.h"
 
-const char DevInfos_MTP_Extensions[] = "microsoft.com: 1.0; android.com: 1.0;";
-
 typedef struct _opcodestring
 {
 	const char * str;

--- a/src/mtp_datasets.c
+++ b/src/mtp_datasets.c
@@ -59,7 +59,7 @@ int build_deviceinfo_dataset(mtp_ctx * ctx, void * buffer, int maxsize)
 	ofs = poke16(buffer, 0, maxsize, MTP_VERSION);                                                   // Standard Version
 	ofs = poke32(buffer, ofs, maxsize, 0x00000006);                                                  // MTP Vendor Extension ID
 	ofs = poke16(buffer, ofs, maxsize, MTP_VERSION);                                                 // MTP Version
-	ofs = poke_string(buffer, ofs, maxsize, "");                                                     // MTP Extensions
+	ofs = poke_string(buffer, ofs, maxsize, ctx->usb_cfg.usb_string_mtp_extensions);                 // MTP Extensions
 	ofs = poke16(buffer, ofs, maxsize, 0x0000);                                                      // Functional Mode
 	ofs = poke_array(buffer, ofs, maxsize, supported_op_size, 2, (void*)&supported_op,1);            // Operations Supported
 	ofs = poke_array(buffer, ofs, maxsize, supported_event_size, 2, (void*)&supported_event,1);      // Events Supported

--- a/src/mtp_datasets.c
+++ b/src/mtp_datasets.c
@@ -59,7 +59,7 @@ int build_deviceinfo_dataset(mtp_ctx * ctx, void * buffer, int maxsize)
 	ofs = poke16(buffer, 0, maxsize, MTP_VERSION);                                                   // Standard Version
 	ofs = poke32(buffer, ofs, maxsize, 0x00000006);                                                  // MTP Vendor Extension ID
 	ofs = poke16(buffer, ofs, maxsize, MTP_VERSION);                                                 // MTP Version
-	ofs = poke_string(buffer, ofs, maxsize, DevInfos_MTP_Extensions);                                // MTP Extensions
+	ofs = poke_string(buffer, ofs, maxsize, "");                                                     // MTP Extensions
 	ofs = poke16(buffer, ofs, maxsize, 0x0000);                                                      // Functional Mode
 	ofs = poke_array(buffer, ofs, maxsize, supported_op_size, 2, (void*)&supported_op,1);            // Operations Supported
 	ofs = poke_array(buffer, ofs, maxsize, supported_event_size, 2, (void*)&supported_event,1);      // Events Supported


### PR DESCRIPTION
Remove legacy MTP extension string ("microsoft.com: 1.0; android.com: 1.0;") from DevInfos_MTP_Extensions[] and set it to an empty string. These identifiers were originally intended to point to vendor-specific documentation per the MTP spec [1], but no such documentation exists — even the Internet Archive has no record of it.

This string inadvertently triggers libmtp's [2] vendor-specific quirk handling, which includes problematic flags such as:
- DEVICE_FLAG_UNLOAD_DRIVER
- DEVICE_FLAG_FORCE_RESET_ON_CLOSE

These flags are applied when libmtp detects an "Android device" and assigns default bug flags [3], causing the USB connection to be reset after each transfer. This behavior is especially disruptive on multi-function USB devices, where the USB-gadget interface also serves as e.g. the primary SSH entry point. Frequent resets during rapid MTP file transfers lead to intermittent network disconnects and test failures.

By clearing the extension string, we prevent libmtp from applying these quirks, improving stability and preserving USB functionality during stress tests. There is no other impact on MTP functionality, as both umpt-responder and libmtp do nothing else with these extension strings; and the supported MTP operations are both listed and handled separately.

Links:
https://www.usb.org/document-library/media-transfer-protocol-v11-spec-and-mtp-v11-adopters-agreement https://libmtp.sourceforge.net/
https://github.com/libmtp/libmtp/blob/master/src/device-flags.h#L320

----

**Tested** (so far):
- [x] linux device with utmp -> linux host, libmtp-tools (raspberry-pi 4, running yocto
- [x] linux device with umtp -> linux host, gvfs->libmtp (x86-64, gnome/debian)
- [ ] linux device with utmp -> android mobile "host"
- [ ] linux device with umtp -> apple iOS mobile host
- [ ] linux device with umtp -> apple iOS pc host
- [x] linux device with umtp -> windows pc host
- [ ] linux device with umtp -> windows mobile host

*Request for support/testers*, since i don't have all combinations at hand :-)

----

**CC** @gujie-leica @bith3ad