### PR TITLE
Fix MTP I/O thread hang on USB cable unplug during transfer

### DIFF
--- a/src/usb_gadget.c
+++ b/src/usb_gadget.c
@@ -116,6 +116,8 @@ int write_usb(usb_gadget * ctx, int channel, unsigned char * buffer, int size)
 			}while( ret < 0 && ( (errno == EAGAIN) || (errno == EWOULDBLOCK) ) && !mtp_context->cancel_req );
 			fcntl(ctx->ep_handles[channel], F_SETFL, fcntl(ctx->ep_handles[channel], F_GETFL) & ~O_NONBLOCK);
 #else
+			if (!is_usb_up(ctx))
+				return -1;
 
 			ret = write (ctx->ep_handles[channel], buffer, size);
 
@@ -808,6 +810,17 @@ int handle_ffs_ep0(usb_gadget * ctx)
 				ctx->stop = 1;
 				if( !ctx->thread_not_started )
 				{
+					if(mtp_context->transferring_file_data)
+					{
+						if(!pthread_mutex_lock(&mtp_context->cancel_mutex))
+						{
+							mtp_context->cancel_req = 2;
+							pthread_kill(ctx->thread, SIGUSR1);
+							pthread_mutex_unlock(&mtp_context->cancel_mutex);
+						}
+						usleep(1000);
+					}
+
 					pthread_join(ctx->thread, NULL);
 					ctx->thread_not_started = 1;
 				}


### PR DESCRIPTION
When a USB cable was unplugged mid-transfer, the MTP I/O thread could remain blocked on write() calls to a disconnected endpoint, preventing the device from becoming accessible again on replug.

Changes:
1. Add USB connection state check in write_usb() before blocking write operations. Returns -1 immediately if USB is disconnected (is_usb_up() check in blocking write path).

2. Enhance USB disconnect handler (FUNCTIONFS_DISABLE event) to synchronously cancel ongoing file transfers:
   - Check if transferring_file_data is active
   - Safely acquire cancel_mutex
   - Set cancel_req=2 to signal force cancellation
   - Send SIGUSR1 to interrupt blocking operations
   - Brief sleep to allow signal processing
   - Join I/O thread before cleanup
   
   CC: @js731ca 