### PR TITLE
Fix #142 and add graceful shutdown via signal handling

### DIFF
--- a/inc/msgqueue.h
+++ b/inc/msgqueue.h
@@ -2,5 +2,7 @@
 
 int msgqueue_handler_init( mtp_ctx * ctx );
 int msgqueue_handler_deinit( mtp_ctx * ctx );
-mqd_t get_message_queue();
+
+mqd_t get_message_queue(int create);
+
 int send_message_queue( char * message );

--- a/inc/mtp.h
+++ b/inc/mtp.h
@@ -26,6 +26,10 @@
 #ifndef _INC_MTP_H_
 #define _INC_MTP_H_
 
+#include <signal.h>
+
+extern volatile sig_atomic_t shutdown_requested;
+
 #define MAX_STORAGE_NB 16
 #define MAX_CFG_STRING_SIZE 512
 

--- a/src/inotify.c
+++ b/src/inotify.c
@@ -322,6 +322,8 @@ static void* inotify_thread(void* arg)
 		}
 		else
 		{
+			if (shutdown_requested)
+				break;
 			PRINT_DEBUG( "inotify_thread : read error %d",length );
 			return NULL;
 		}

--- a/src/msgqueue.c
+++ b/src/msgqueue.c
@@ -246,8 +246,16 @@ error:
 	return NULL;
 }
 
-mqd_t get_message_queue() {
-	mqd_t qid = mq_open("/umtprd", O_RDWR | O_CREAT, 0600, &qattrs);
+mqd_t get_message_queue(int create) {
+
+	int flags = O_RDWR;
+
+	if (create)
+	{
+		flags |= O_CREAT;
+	}
+
+	mqd_t qid = mq_open("/umtprd", flags, 0600, &qattrs);
 	if (qid < 0)
 	{
 		PRINT_ERROR("%s : mq_open error %d (%s)", __func__, errno, strerror(errno));
@@ -263,7 +271,7 @@ int send_message_queue(char * message )
 {
 	mqd_t msgqueue_id;
 
-	msgqueue_id = get_message_queue();
+	msgqueue_id = get_message_queue(0);
 	if (msgqueue_id != -1)
 	{
 		if (mq_send(msgqueue_id, message, strlen(message) + 1, 0) == 0 )
@@ -285,7 +293,7 @@ int msgqueue_handler_init(mtp_ctx * ctx )
 
 	if( ctx )
 	{
-		ctx->msgqueue_id = get_message_queue();
+		ctx->msgqueue_id = get_message_queue(1);
 		if(ctx->msgqueue_id != -1)
 		{
 			ret = pthread_create(&ctx->msgqueue_thread, NULL, msgqueue_thread, ctx);

--- a/src/msgqueue.c
+++ b/src/msgqueue.c
@@ -56,6 +56,8 @@
 // minimum message size for POSIX queues on Linux
 #define MAX_MSG_SIZE 128
 
+#define MQ_PATH "/umtprd"
+
 static struct mq_attr qattrs = {
   0,  // flags
   20, // max number of messages on the queue
@@ -255,7 +257,7 @@ mqd_t get_message_queue(int create) {
 		flags |= O_CREAT;
 	}
 
-	mqd_t qid = mq_open("/umtprd", flags, 0600, &qattrs);
+	mqd_t qid = mq_open(MQ_PATH, flags, 0600, &qattrs);
 	if (qid < 0)
 	{
 		PRINT_ERROR("%s : mq_open error %d (%s)", __func__, errno, strerror(errno));
@@ -323,6 +325,7 @@ int msgqueue_handler_deinit( mtp_ctx * ctx )
 			pthread_kill( ctx->msgqueue_thread, SIGUSR1);
 			pthread_join( ctx->msgqueue_thread, &ret);
 			mq_close(ctx->msgqueue_id);
+			mq_unlink(MQ_PATH);
 		}
 
 		return 1;

--- a/src/msgqueue.c
+++ b/src/msgqueue.c
@@ -99,7 +99,10 @@ static void* msgqueue_thread( void* arg )
 		ssize_t numreceived = mq_receive(ctx->msgqueue_id, message, MAX_MSG_SIZE + 1, NULL);
 		if (numreceived < 0)
 		{
+			if (shutdown_requested)
+				break;
 			PRINT_ERROR("error receiving: %s", strerror(errno));
+			continue;
 		}
 		else if (numreceived <= MAX_MSG_SIZE)
 		{
@@ -236,7 +239,7 @@ static void* msgqueue_thread( void* arg )
 			PRINT_DEBUG("received message of size %zd", numreceived);
 		}
 
-	} while(1);
+	} while(!shutdown_requested);
 
 	PRINT_DEBUG("%s : Leaving thread", __func__);
 

--- a/src/umtprd.c
+++ b/src/umtprd.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <sys/prctl.h>
 #include <sys/file.h>
+#include <signal.h>
 
 #ifdef SYSTEMD_NOTIFY
 #include <systemd/sd-login.h>
@@ -50,6 +51,14 @@
 #include "default_cfg.h"
 
 mtp_ctx * mtp_context;
+
+volatile sig_atomic_t shutdown_requested = 0;
+
+static void shutdown_signal_handler(int sig)
+{
+	PRINT_MSG("Received shutdown signal %d, initiating graceful shutdown", sig);
+	shutdown_requested = 1;
+}
 
 void* io_thread(void* arg)
 {
@@ -126,7 +135,7 @@ static int main_thread(const char *conffile)
 			deinit_fs_db(mtp_context->fs_db);
 			mtp_context->fs_db = 0;
 		}
-	}while(loop_continue);
+	}while(loop_continue && !shutdown_requested);
 
 	mtp_deinit_responder(mtp_context);
 
@@ -218,6 +227,14 @@ int main(int argc, char *argv[])
 
 	if (!cmd_sent && !already_running)
 	{
+		struct sigaction sa;
+		memset(&sa, 0, sizeof(sa));
+		sa.sa_handler = shutdown_signal_handler;
+		sigemptyset(&sa.sa_mask);
+		sa.sa_flags = 0;
+		sigaction(SIGTERM, &sa, NULL);
+		sigaction(SIGINT, &sa, NULL);
+
 		PRINT_DEBUG("starting main thread");
 		retcode = main_thread(conffile);
 		if( retcode )

--- a/src/umtprd.c
+++ b/src/umtprd.c
@@ -136,30 +136,39 @@ static int main_thread(const char *conffile)
 #define PARAMETER_IPCCMD "-cmd:"
 #define PARAMETER_CONF "-conf"
 
+int check_running()
+{
+	mqd_t fd = get_message_queue(0);
+	if (fd < 0)
+	{
+		// No queue: not running
+		return 0;
+	}
+
+	int ret = flock(fd, LOCK_EX | LOCK_NB);
+	if (ret != 0)
+	{
+		// Lock fails: daemon is running.
+		mq_close(fd);
+		return 1;
+	}
+
+	// Lock acquired: not running.
+	return 0;
+}
+
 int main(int argc, char *argv[])
 {
 	const char *conffile = UMTPR_CONF_FILE;
-	int retcode;
-	mqd_t fd = -1;
-	int already_running = 0;
+	int retcode = 0;
+	int already_running = check_running();
+	int cmd_sent = 0;
 
 	PRINT_MSG("uMTP Responder");
 	PRINT_MSG("Version: %s compiled %s@%s", APP_VERSION,
 		  __DATE__, __TIME__);
 
 	PRINT_MSG("(c) 2018 - 2025 Viveris Technologies");
-
-	fd = get_message_queue();
-	if (fd < 0)
-	{
-		exit(1);
-	}
-	retcode = flock(fd, LOCK_EX | LOCK_NB);
-	if (retcode)
-	{
-		// lock failed, umtprd is already running
-		already_running = 1;
-	}
 
 	if (argc <= 1 && already_running)
 	{
@@ -179,6 +188,7 @@ int main(int argc, char *argv[])
 				PRINT_ERROR("Error (%d) sending '%s'", retcode, cmd);
 				exit(retcode);
 			}
+			cmd_sent = 1;
 			argc--;
 			argv++;
 		}
@@ -206,7 +216,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (!already_running)
+	if (!cmd_sent && !already_running)
 	{
 		PRINT_DEBUG("starting main thread");
 		retcode = main_thread(conffile);

--- a/src/usb_gadget.c
+++ b/src/usb_gadget.c
@@ -624,7 +624,17 @@ int handle_ep0(usb_gadget * ctx)
 		if(ctx->wait_connection && ret == 0 )
 			continue;
 
-		if( ret <= 0 )
+		if( ret < 0 )
+		{
+			if( shutdown_requested )
+			{
+				ctx->stop = 1;
+				goto end;
+			}
+			continue;
+		}
+
+		if( ret == 0 )
 			return ret;
 
 		timeout.tv_sec = 0;
@@ -759,7 +769,17 @@ int handle_ffs_ep0(usb_gadget * ctx)
 		if(ctx->wait_connection && ret == 0 )
 			continue;
 
-		if( ret <= 0 )
+		if( ret < 0 )
+		{
+			if( shutdown_requested )
+			{
+				ctx->stop = 1;
+				goto end;
+			}
+			continue;
+		}
+
+		if( ret == 0 )
 			return ret;
 
 		timeout.tv_sec = 0;


### PR DESCRIPTION
- Fix #142: umtprd -cmd: no longer blocks indefinitely when the daemon is not running. The command mode now detects whether a daemon instance is active before attempting to send messages.
- Message queue cleanup: the message queue is properly unlinked on exit, preventing stale queues from misleading subsequent check_running() calls.
- Graceful shutdown on SIGTERM/SIGINT: the daemon now shuts down cleanly instead of requiring kill -9.

  Why signal handling was needed

  Previously, umtprd had no handler for SIGTERM or SIGINT. The only way to stop the daemon was kill -9, which immediately terminates the process without running any cleanup logic. This left resources in an unclean state: open USB gadget file descriptors, an orphaned POSIX message queue, active inotify
  watches, and allocated memory. Systemd's default stop mechanism sends SIGTERM, so without a handler the daemon would ignore it entirely, forcing systemd to escalate to SIGKILL after a timeout.

  The fix introduces a volatile sig_atomic_t shutdown_requested flag set by a signal handler registered with sa_flags = 0 (no SA_RESTART). This ensures that blocking syscalls (select, mq_receive, read) are interrupted with EINTR when the signal arrives. Each event loop checks the flag and exits cleanly,
  allowing the existing deinit functions to close file descriptors, join threads, and free memory in the correct order.
